### PR TITLE
Fix variable name for deleting the existing api spec in update_spec_auto.sh

### DIFF
--- a/update_spec_auto.sh
+++ b/update_spec_auto.sh
@@ -21,7 +21,7 @@ SPEC_DOCUMENT=$(cat ${SPEC_FILEPATH} | jq -sR .)
 if [ ${SPEC_DOCUMENT_ID} != null ]
 then
        echo "Deleting current document id: ${SPEC_DOCUMENT_ID}"
-       curl -s -H "Authorization: Bearer ${KONNECT_TOKEN}" -X DELETE https://us.api.konghq.com/konnect-api/api/service_versions/${SERVICE_VERSION_ID}/documents/${DOCUMENT_ID}
+       curl -s -H "Authorization: Bearer ${KONNECT_TOKEN}" -X DELETE https://us.api.konghq.com/konnect-api/api/service_versions/${SERVICE_VERSION_ID}/documents/${SPEC_DOCUMENT_ID}
        echo "Successfully deleted ${SPEC_DOCUMENT_ID} to Service version id ${SERVICE_VERSION_ID}\n"
 fi
 


### PR DESCRIPTION
Thanks for posting this Ross, it's saved me a lot of time trying to watch API calls in a web browser :)

A minor thing I noticed:

The script `update_spec_auth.sh` fails because it first needs to delete an existing spec file.

An existing file id is queried and stored in `SPEC_DOCUMENT_ID`, but in the HTTP DELETE request, it uses a different variable name `DOCUMENT_ID`. This PR adds the missing `SPEC_` to the variable name.